### PR TITLE
safety checks

### DIFF
--- a/csrc/device.cc
+++ b/csrc/device.cc
@@ -31,6 +31,7 @@ void NetworkDevice::run(void)
 
     while (true) {
         while (!out_flits.empty()) {
+            assert(send_packet->len < ETH_MAX_WORDS);
             network_packet_add(send_packet, out_flits.front().data);
             if (out_flits.front().last) {
                 out_packets.push(send_packet);

--- a/csrc/device.h
+++ b/csrc/device.h
@@ -3,6 +3,7 @@
 
 #include <queue>
 #include <stdint.h>
+#include <cassert>
 
 #include "fesvr/context.h"
 #include "packet.h"

--- a/src/main/scala/NIC.scala
+++ b/src/main/scala/NIC.scala
@@ -212,6 +212,7 @@ class IceNicReaderModule(outer: IceNicReader)
     sendpart := packpart
     state := s_read
 
+    assert(packlen > 0.U, s"NIC packet length must be >0")
     assert(packaddr(byteAddrBits-1,0) === 0.U &&
            packlen(byteAddrBits-1,0)  === 0.U,
            s"NIC send address and length must be aligned to ${beatBytes} bytes")


### PR DESCRIPTION
fixes a problem where if the packet length is 0, the nic will send packets larger than 1500 bytes and libicenet.so corrupts the heap.