### PR TITLE
Use fbus/pbus instead of sbus to connect NIC

### DIFF
--- a/src/main/scala/NIC.scala
+++ b/src/main/scala/NIC.scala
@@ -330,9 +330,9 @@ trait HasPeripheryIceNIC  { this: BaseSubsystem =>
   private val address = BigInt(0x10016000)
   private val portName = "Ice-NIC"
 
-  val icenic = LazyModule(new IceNIC(address, sbus.beatBytes))
-  sbus.toVariableWidthSlave(Some(portName)) { icenic.mmionode }
-  sbus.fromPort(Some(portName))() :=* icenic.dmanode
+  val icenic = LazyModule(new IceNIC(address, pbus.beatBytes))
+  pbus.toVariableWidthSlave(Some(portName)) { icenic.mmionode }
+  fbus.fromPort(Some(portName))() :=* icenic.dmanode
   ibus.fromSync := icenic.intnode
 }
 


### PR DESCRIPTION
This is the commit chipyard master is pointing to. It should be merged to icenet master.