### PR TITLE
Separate NIC connect methods into an object for easier reusability

### DIFF
--- a/src/main/scala/NIC.scala
+++ b/src/main/scala/NIC.scala
@@ -480,40 +480,57 @@ trait CanHavePeripheryIceNICModuleImp extends LazyModuleImp {
     nicio
   }
 
-  import PauseConsts.BT_PER_QUANTA
-
   val nicConf = p(NICKey).getOrElse(NICConfig())
-  private val packetWords = nicConf.packetMaxBytes / NET_IF_BYTES
-  private val packetQuanta = (nicConf.packetMaxBytes * 8) / BT_PER_QUANTA
 
-  def connectNicLoopback(qDepth: Int = 4 * packetWords, latency: Int = 10) {
-    val netio = net.get
-    netio.macAddr := PlusArg("macaddr")
-    netio.rlimit.inc := PlusArg("rlimit-inc", 1)
-    netio.rlimit.period := PlusArg("rlimit-period", 1)
-    netio.rlimit.size := PlusArg("rlimit-size", 8)
-    netio.pauser.threshold := PlusArg("pauser-threshold", 2 * packetWords + latency)
-    netio.pauser.quanta := PlusArg("pauser-quanta", 2 * packetQuanta)
-    netio.pauser.refresh := PlusArg("pauser-refresh", packetWords)
+  def connectNicLoopback(qDepth: Int, latency: Int) = NicLoopback.connect(net, nicConf, qDepth, latency)
+  def connectNicLoopback(qDepth: Int) = NicLoopback.connect(net, nicConf, qDepth)
+  def connectNicLoopback() = NicLoopback.connect(net, nicConf)
 
-    if (nicConf.usePauser) {
-      val pauser = Module(new PauserComplex(qDepth))
-      pauser.io.ext.flipConnect(NetDelay(NICIO(netio), latency))
-      pauser.io.int.out <> pauser.io.int.in
-      pauser.io.macAddr := netio.macAddr + (1 << 40).U
-      pauser.io.settings := netio.pauser
-    } else {
+  def connectSimNetwork(clock: Clock, reset: Bool) = SimNetwork.connect(net, clock, reset)
+}
 
-      netio.in := Pipe(netio.out, latency)
+
+object NicLoopback {
+  def connect(net: Option[NICIOvonly], nicConf: NICConfig, qDepth: Int, latency: Int = 10) {
+    net.foreach { netio =>
+      import PauseConsts.BT_PER_QUANTA
+      val packetWords = nicConf.packetMaxBytes / NET_IF_BYTES
+      val packetQuanta = (nicConf.packetMaxBytes * 8) / BT_PER_QUANTA
+      netio.macAddr := PlusArg("macaddr")
+      netio.rlimit.inc := PlusArg("rlimit-inc", 1)
+      netio.rlimit.period := PlusArg("rlimit-period", 1)
+      netio.rlimit.size := PlusArg("rlimit-size", 8)
+      netio.pauser.threshold := PlusArg("pauser-threshold", 2 * packetWords + latency)
+      netio.pauser.quanta := PlusArg("pauser-quanta", 2 * packetQuanta)
+      netio.pauser.refresh := PlusArg("pauser-refresh", packetWords)
+
+      if (nicConf.usePauser) {
+        val pauser = Module(new PauserComplex(qDepth))
+        pauser.io.ext.flipConnect(NetDelay(NICIO(netio), latency))
+        pauser.io.int.out <> pauser.io.int.in
+        pauser.io.macAddr := netio.macAddr + (1 << 40).U
+        pauser.io.settings := netio.pauser
+      } else {
+
+        netio.in := Pipe(netio.out, latency)
+      }
+      netio.in.bits.keep := NET_FULL_KEEP
     }
-    netio.in.bits.keep := NET_FULL_KEEP
   }
 
-  def connectSimNetwork(clock: Clock, reset: Bool) {
-    val sim = Module(new SimNetwork)
-    sim.io.clock := clock
-    sim.io.reset := reset
-    sim.io.net <> net.get
+  def connect(net: Option[NICIOvonly], nicConf: NICConfig) {
+    val packetWords = nicConf.packetMaxBytes / NET_IF_BYTES
+    NicLoopback.connect(net, nicConf, 4 * packetWords)
   }
 }
 
+object SimNetwork {
+  def connect(net: Option[NICIOvonly], clock: Clock, reset: Bool) {
+    net.foreach { netio =>
+      val sim = Module(new SimNetwork)
+      sim.io.clock := clock
+      sim.io.reset := reset
+      sim.io.net <> netio
+    }
+  }
+}


### PR DESCRIPTION
This separates the connect methods in the NIC into an object, making the code easier to reuse (e.g. so a chipyard Top and ChipTop can share code, see ucb-bar/chipyard#480). Should be backwards compatible.