### PR TITLE
NIC DMA requires minLatency > 0

### DIFF
--- a/src/main/scala/DMA.scala
+++ b/src/main/scala/DMA.scala
@@ -54,6 +54,8 @@ class StreamReaderCore(nXacts: Int, outFlits: Int, maxBytes: Int)
     val addrBits = tl.params.addressBits
     val lenBits = 15
 
+    require (edge.manager.minLatency > 0)
+
     val io = IO(new Bundle {
       val req = Flipped(Decoupled(new StreamReadRequest))
       val resp = Decoupled(Bool())
@@ -187,6 +189,8 @@ class StreamWriter(nXacts: Int, maxBytes: Int)
     val byteAddrBits = log2Ceil(beatBytes)
     val addrBits = tl.params.addressBits
     val lenBits = 16
+
+    require (edge.manager.minLatency > 0)
 
     val io = IO(new Bundle {
       val req = Flipped(Decoupled(new StreamWriteRequest))


### PR DESCRIPTION
The state machines in the DMA reader and writer depend on there being at least a cycle of latency between A and D. Add a require to make sure this assumption holds true.