### PR TITLE
Change the input/output taps to vectors and fix possible deadlocks

### DIFF
--- a/src/main/scala/NIC.scala
+++ b/src/main/scala/NIC.scala
@@ -322,7 +322,9 @@ class IceNicRecvPathModule(outer: IceNicRecvPath)
 
   val buffers = allDropChecks.map(dropChecks =>
     Module(new NetworkPacketBuffer(
-      inBufFlits, dropChecks = dropChecks, dropless = usePauser)))
+      inBufFlits,
+      maxBytes = packetMaxBytes,
+      dropChecks = dropChecks, dropless = usePauser)))
   duplicateStream(io.in, buffers.map(_.io.stream.in))
 
   io.buf_free := buffers.map(_.io.free)

--- a/src/main/scala/NIC.scala
+++ b/src/main/scala/NIC.scala
@@ -172,8 +172,7 @@ class IceNicSendPath(nInputTaps: Int = 0)(implicit p: Parameters)
   lazy val module = new LazyModuleImp(this) {
     val io = IO(new Bundle {
       val send = Flipped(new IceNicSendIO)
-      val tap = (nInputTaps > 0).option(
-        Flipped(Vec(nInputTaps, Decoupled(new StreamChannel(NET_IF_WIDTH)))))
+      val tap = Flipped(Vec(nInputTaps, Decoupled(new StreamChannel(NET_IF_WIDTH))))
       val out = Decoupled(new StreamChannel(NET_IF_WIDTH))
       val rlimit = Input(new RateLimiterSettings)
       val csum = checksumOffload.option(new Bundle {
@@ -212,7 +211,7 @@ class IceNicSendPath(nInputTaps: Int = 0)(implicit p: Parameters)
 
     val unlimitedOut = if (nInputTaps > 0) {
       val arb = Module(new PacketArbiter(1 + nInputTaps, rr = true))
-      arb.io.in <> (preArbOut +: io.tap.get)
+      arb.io.in <> (preArbOut +: io.tap)
       arb.io.out
     } else { preArbOut }
 
@@ -273,8 +272,7 @@ class IceNicRecvPathModule(outer: IceNicRecvPath)
   val io = IO(new Bundle {
     val recv = Flipped(new IceNicRecvIO)
     val in = Flipped(Decoupled(new StreamChannel(NET_IF_WIDTH))) // input stream 
-    val tap = outer.tapFuncs.nonEmpty.option(
-      Vec(outer.tapFuncs.length, Decoupled(new StreamChannel(NET_IF_WIDTH))))
+    val tap = Vec(outer.tapFuncs.length, Decoupled(new StreamChannel(NET_IF_WIDTH)))
     val csum = checksumOffload.option(new Bundle {
       val res = Decoupled(new TCPChecksumOffloadResult)
       val enable = Input(Bool())
@@ -291,7 +289,7 @@ class IceNicRecvPathModule(outer: IceNicRecvPath)
   val tapout = if (outer.tapFuncs.nonEmpty) {
     val tap = Module(new NetworkTap(outer.tapFuncs))
     tap.io.inflow <> buffer.io.stream.out
-    io.tap.get <> tap.io.tapout
+    io.tap <> tap.io.tapout
     tap.io.passthru
   } else { buffer.io.stream.out }
 
@@ -377,10 +375,8 @@ class IceNIC(address: BigInt, beatBytes: Int = 8,
   lazy val module = new LazyModuleImp(this) {
     val io = IO(new Bundle {
       val ext = new NICIO
-      val tapOut = tapOutFuncs.nonEmpty.option(
-        Vec(tapOutFuncs.length, Decoupled(new StreamChannel(NET_IF_WIDTH))))
-      val tapIn = (nInputTaps > 0).option(
-        Flipped(Vec(nInputTaps, Decoupled(new StreamChannel(NET_IF_WIDTH)))))
+      val tapOut = Vec(tapOutFuncs.length, Decoupled(new StreamChannel(NET_IF_WIDTH)))
+      val tapIn = Flipped(Vec(nInputTaps, Decoupled(new StreamChannel(NET_IF_WIDTH))))
     })
 
     sendPath.module.io.send <> control.module.io.send
@@ -404,12 +400,8 @@ class IceNIC(address: BigInt, beatBytes: Int = 8,
     control.module.io.macAddr := io.ext.macAddr
     sendPath.module.io.rlimit := io.ext.rlimit
 
-    io.tapOut.zip(recvPath.module.io.tap).foreach {
-      case (a, b) => a <> b
-    }
-    sendPath.module.io.tap.zip(io.tapIn).foreach {
-      case (a, b) => a <> b
-    }
+    io.tapOut <> recvPath.module.io.tap
+    sendPath.module.io.tap <> io.tapIn
 
     if (checksumOffload) {
       sendPath.module.io.csum.get.req <> control.module.io.txcsumReq

--- a/src/main/scala/Pauser.scala
+++ b/src/main/scala/Pauser.scala
@@ -43,6 +43,12 @@ object PauseDropCheck extends NetworkEndianHelpers {
   }
 }
 
+/**
+ * Flow control unit using Ethernet pause frames
+ * See https://en.wikipedia.org/wiki/Ethernet_flow_control#Pause_frame
+ * @creditInit Size of each buffer being tracked
+ * @nBuckets Number of buffers being tracked
+ */
 class Pauser(creditInit: Int, nBuckets: Int) extends Module
     with NetworkEndianHelpers {
   val timerBits = 16 + log2Ceil(CYCLES_PER_QUANTA)

--- a/src/main/scala/Tap.scala
+++ b/src/main/scala/Tap.scala
@@ -57,7 +57,7 @@ class NetworkTap[T <: Data](
   io.passthru.bits.last := MuxLookup(Cat(state, hasTapout), false.B, Seq(
     Cat(s_output_header, false.B) -> (bodyLess && headerIdx === headerLen),
     Cat(s_forward_body,  false.B) -> io.inflow.bits.last))
-  io.passthru.bits.keep := DontCare
+  io.passthru.bits.keep := NET_FULL_KEEP
 
   io.tapout.zip(route).foreach { case (tapout, sel) =>
     tapout.valid := MuxLookup(Cat(state, sel), false.B, Seq(
@@ -69,7 +69,7 @@ class NetworkTap[T <: Data](
     tapout.bits.last := MuxLookup(Cat(state, sel), false.B, Seq(
       Cat(s_output_header, true.B) -> (bodyLess && headerIdx === headerLen),
       Cat(s_forward_body,  true.B) -> io.inflow.bits.last))
-    tapout.bits.keep := DontCare
+    tapout.bits.keep := NET_FULL_KEEP
   }
 
   when (state === s_collect_header && io.inflow.valid) {
@@ -144,8 +144,6 @@ class NetworkTapTest extends UnitTest {
   tap.io.inflow <> genIn.io.out
   checkTap.io.in <> tap.io.tapout(0)
   checkPass.io.in <> tap.io.passthru
-  checkTap.io.in.bits.keep := NET_FULL_KEEP
-  checkPass.io.in.bits.keep := NET_FULL_KEEP
 
   io.finished := checkTap.io.finished || checkPass.io.finished
 }


### PR DESCRIPTION
This PR includes the fixes I made to the input/output taps. The changes are detailed below

1. Since there's no longer an issue with zero-length vectors in Chisel, I change the tapIn and tapOut interfaces from an option of a vector to just a vector.
2. Instead of packets for all output taps being pulled from a shared buffer, incoming packets get duplicated into one buffer per tap (plus one for the receive path). Packets not destined for that tap get dropped from the buffer.
3. If there are input taps, a packet collection buffer is put in from of every input interface. The collection buffer only sends out data once the complete packet is received. This ensures that the arbiter won't be locked up.