### PR TITLE
Fix NetworkPacketBuffer maxWords calculation

### DIFF
--- a/src/main/scala/Buffer.scala
+++ b/src/main/scala/Buffer.scala
@@ -60,10 +60,12 @@ class NetworkPacketBuffer[T <: Data](
     dropChecks: Seq[(T, StreamChannel, Bool) => Bool] = Nil,
     dropless: Boolean = false) extends Module {
 
-  val maxWords = maxBytes / wordBytes
+  val maxWords = (maxBytes - 1) / wordBytes + 1
   val headerWords = headerBytes / wordBytes
   val wordBits = wordBytes * 8
   val nPackets = (bufWords - 1) / (headerWords + 1) + 1
+
+  require(headerBytes % wordBytes == 0)
 
   val idxBits = log2Ceil(bufWords)
   val phaseBits = log2Ceil(nPackets + 1)


### PR DESCRIPTION
The calculation of ``maxWords`` in the receive buffer will be incorrect if ``maxBytes`` isn't divisible by ``wordBytes``. This leads to maximum-size packets being dropped. 