### PR TITLE
TLManagerParameters is deprecated: Use TLSlaveParameters.v1

### DIFF
--- a/src/main/scala/TCAM.scala
+++ b/src/main/scala/TCAM.scala
@@ -24,7 +24,7 @@ class TCAM(address: BigInt, val n: Int, val dataBits: Int, val nPorts: Int)
   val beatBytes = 1 << byteAddrBits
   val addrMask = (1 << (1 + addrBits + byteAddrBits)) - 1
 
-  val node = TLHelper.makeManagerNode(beatBytes, TLManagerParameters(
+  val node = TLHelper.makeManagerNode(beatBytes, TLSlaveParameters.v1(
     address = Seq(AddressSet(address, addrMask)),
     regionType = RegionType.PUT_EFFECTS,
     supportsGet = TransferSizes(1, beatBytes),


### PR DESCRIPTION
**Type of change**: paying off technical debt

**Impact**: no functional change

**What was changed**
fix compile warning:
```
[warn] /icenet/src/main/scala/TCAM.scala:27:50: method apply in object TLManagerParameters is deprecated: Use TLSlaveParameters.v1 instead of TLManagerParameters
[warn]   val node = TLHelper.makeManagerNode(beatBytes, TLManagerParameters(
[warn]                                                  ^
```